### PR TITLE
Add option to control building with syslog facility enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,15 @@ endif()
 # Option to control library installation
 option(logger_INSTALL "Install the Logger Library" ON)
 
+# Option to enable syslog support (on by default, except for WIN32)
+if(NOT WIN32)
+    option(logger_ENABLE_SYSLOG "Enable Logger's Syslog Support" ON)
+else()
+    option(logger_ENABLE_SYSLOG "Enable Logger's Syslog Support" OFF)
+endif()
+
 project(logger
-        VERSION 1.0.0.0
+        VERSION 1.1.0.0
         DESCRIPTION "Logger Library for C++ Projects"
         LANGUAGES CXX)
 

--- a/README.md
+++ b/README.md
@@ -129,3 +129,14 @@ LOGGER_DEBUG(logger, "ID: " << id << ", Length: " << length)
 
 Note that `std::flush` is appended, so there is no need to explicitly
 attempt to flush the output stream when using these macros.
+
+## Enabling or Disabling Logger Options
+
+When using Logger in your software, you may disable options exposed in the
+top-level CMakeLists.txt file.  For example, to disable the syslog interface
+for platforms that do not support syslog, set this option in your CMakeLists.txt
+file before adding the Logger directory, FetchContent, etc.
+
+```CMake
+set(logger_ENABLE_SYSLOG OFF CACHE BOOL "Enable Logger's Syslog Support")
+```

--- a/include/cantina/syslog_interface.h
+++ b/include/cantina/syslog_interface.h
@@ -7,9 +7,9 @@
  *
  *  Description:
  *      This defines a SyslogInterface class, which was originally written to
- *      facilitate unit testing. It still serves that purpose, but also
- *      simplifies interacting with alternate system logging functions
- *      on different platforms.
+ *      facilitate unit testing.  It still serves that purpose, but may also
+ *      simplify interacting with alternate system logging functions on
+ *      different platforms.
  *
  *  Portability Issues:
  *      None.
@@ -18,10 +18,6 @@
 
 #pragma once
 
-#ifndef _WIN32
-#include <syslog.h>
-#endif
-
 namespace cantina
 {
 
@@ -29,30 +25,14 @@ namespace cantina
 class SyslogInterface
 {
     public:
-        virtual ~SyslogInterface() {}
+        SyslogInterface() = default;
+        virtual ~SyslogInterface() = default;
 
-        virtual void openlog(const char *ident, int option, int facility)
-        {
-#ifndef _WIN32
-            ::openlog(ident, option, facility);
-#endif
-        }
+        virtual void openlog(const char *ident, int option, int facility);
 
-        virtual void closelog(void)
-        {
-#ifndef _WIN32
-            ::closelog();
-#endif
-        }
+        virtual void closelog(void);
 
-        template<typename ...Args> void syslog(int priority,
-                                               const char *format,
-                                               Args ...args)
-        {
-#ifndef _WIN32
-            ::syslog(priority, format, args...);
-#endif
-        }
+        virtual void syslog(int priority, const char *format, ...);
 };
 
 } // namespace cantina

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(logger ansi.cpp logger.cpp)
+add_library(logger ansi.cpp logger.cpp syslog_interface.cpp)
 add_library(cantina::logger ALIAS logger)
 
 set_target_properties(logger
@@ -7,9 +7,11 @@ set_target_properties(logger
         CXX_STANDARD_REQUIRED YES
         CXX_EXTENSIONS NO
         PREFIX "libcantina_")
-target_compile_options(logger PRIVATE
-     $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>: -Wpedantic -Wextra -Wall>
-     $<$<CXX_COMPILER_ID:MSVC>: >)
+
+target_compile_options(logger
+    PRIVATE
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>: -Wpedantic -Wextra -Wall>
+        $<$<CXX_COMPILER_ID:MSVC>: >)
 
 # Specify the internal and public include directories
 target_include_directories(logger
@@ -18,6 +20,11 @@ target_include_directories(logger
     PUBLIC
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>)
+
+# Is syslog enabled?
+if(logger_ENABLE_SYSLOG)
+    target_compile_definitions(logger PRIVATE LOGGER_SYSLOG_ENABLED=1)
+endif()
 
 # Install target and associated include files
 if(logger_INSTALL)

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -23,6 +23,9 @@
 #include <stdlib.h>
 #include <strings.h>
 #endif
+#ifdef LOGGER_SYSLOG_ENABLED
+#include <syslog.h>
+#endif
 #include <stdio.h>
 #include <iostream>
 #include <iomanip>
@@ -462,8 +465,9 @@ void Logger::SetLogFacility(LogFacility facility, std::string filename)
         // Open syslog if appropriate
         if (facility == LogFacility::Syslog)
         {
-#ifdef _WIN32
-            error << "Syslog not supported on Windows" << std::flush;
+#ifndef LOGGER_SYSLOG_ENABLED
+            error << "Syslog is not supported on this platform" << std::flush;
+            return;
 #else
             openlog(process_name.c_str(),
                     LOG_PID,
@@ -826,7 +830,7 @@ std::ostream &Logger::GetLoggingStream(LogLevel level)
  */
 int Logger::MapLogLevelToSysLog(LogLevel level) const
 {
-#ifdef _WIN32
+#ifndef LOGGER_SYSLOG_ENABLED
     return 0;
 #else
     int priority;

--- a/src/syslog_interface.cpp
+++ b/src/syslog_interface.cpp
@@ -1,0 +1,119 @@
+/*
+ *  syslog_interface.h
+ *
+ *  Copyright (C) 2022
+ *  Cisco Systems, Inc.
+ *  All Rights Reserved.
+ *
+ *  Description:
+ *      This implements a SyslogInterface class, which was originally written to
+ *      facilitate unit testing.  It still serves that purpose, but may also
+ *      simplify interacting with alternate system logging functions on
+ *      different platforms.
+ *
+ *  Portability Issues:
+ *      None.
+ *
+ */
+
+#ifdef LOGGER_SYSLOG_ENABLED
+#include <syslog.h>
+#include <cstdarg>
+#endif
+#include "cantina/syslog_interface.h"
+
+namespace cantina
+{
+
+/*
+ *  openlog()
+ *
+ *  Description:
+ *      If syslog is enabled on the system, this function will call the
+ *      system's openlog() function().
+ *
+ *  Parameters:
+ *      ident [in]
+ *          String to prepend to every syslog message.
+ *
+ *      option [in]
+ *          Flags which control the operation of openlog() and subsequent calls
+ *          to syslog().
+ *
+ *      facility [in]
+ *          Default facility to use if not specified in subsequent calls to
+ *          syslog().
+ *
+ *  Returns:
+ *      Nothing.
+ *
+ *  Comments:
+ *      None.
+ */
+void SyslogInterface::openlog([[maybe_unused]] const char *ident,
+                              [[maybe_unused]] int option,
+                              [[maybe_unused]] int facility)
+{
+#ifdef LOGGER_SYSLOG_ENABLED
+    ::openlog(ident, option, facility);
+#endif
+}
+
+/*
+ *  closelog()
+ *
+ *  Description:
+ *      Closes the syslog interface opened via openlog().
+ *
+ *  Parameters:
+ *      None.
+ *
+ *  Returns:
+ *      Nothing.
+ *
+ *  Comments:
+ *      None.
+ */
+void SyslogInterface::closelog(void)
+{
+#ifdef LOGGER_SYSLOG_ENABLED
+    ::closelog();
+#endif
+}
+
+/*
+ *  syslog()
+ *
+ *  Description:
+ *      If syslog is enabled on the system, this function will call the
+ *      system's openlog() function().
+ *
+ *  Parameters:
+ *      priority [in]
+ *          The priority associated with this message.
+ *
+ *      format [in]
+ *          A format specifier like what is used with printf().
+ *
+ *      ... [in]
+ *          Variadic arguments passed to the syslog() function.
+ *
+ *  Returns:
+ *      Nothing.
+ *
+ *  Comments:
+ *      None.
+ */
+void SyslogInterface::syslog([[maybe_unused]] int priority,
+                             [[maybe_unused]] const char *format,
+                             ...)
+{
+#ifdef LOGGER_SYSLOG_ENABLED
+    std::va_list arguments;
+    va_start(arguments, format);
+    ::vsyslog(priority, format, arguments);
+    va_end(arguments);
+#endif
+}
+
+} // namespace cantina

--- a/test/custom_logger/CMakeLists.txt
+++ b/test/custom_logger/CMakeLists.txt
@@ -6,6 +6,11 @@ set_target_properties(test_custom_logger
         CXX_STANDARD_REQUIRED YES
         CXX_EXTENSIONS NO)
 
+# Is syslog enabled?
+if(logger_ENABLE_SYSLOG)
+    target_compile_definitions(test_custom_logger PRIVATE LOGGER_SYSLOG_ENABLED=1)
+endif()
+
 target_link_libraries(test_custom_logger PRIVATE cantina::logger GTest::GTest GTest::Main)
 
 add_test(NAME test_custom_logger

--- a/test/logger/CMakeLists.txt
+++ b/test/logger/CMakeLists.txt
@@ -6,6 +6,11 @@ set_target_properties(test_logger
         CXX_STANDARD_REQUIRED YES
         CXX_EXTENSIONS NO)
 
+# Is syslog enabled?
+if(logger_ENABLE_SYSLOG)
+    target_compile_definitions(test_logger PRIVATE LOGGER_SYSLOG_ENABLED=1)
+endif()
+
 target_link_libraries(test_logger PRIVATE cantina::logger GTest::GTest GTest::Main)
 
 add_test(NAME test_logger

--- a/test/logger/test_logger.cpp
+++ b/test/logger/test_logger.cpp
@@ -1,13 +1,13 @@
 #include <atomic>
 #include <iostream>
 #include <cstdio>
-#include "cantina/logger.h"
-#include "gtest/gtest.h"
 
 // Ensure that all logging levels are being logged here
 #undef LOGGER_LEVEL
 #define LOGGER_LEVEL LOGGER_LEVEL_DEBUG
-#include "cantina/logger_macros.h"
+
+#include "cantina/logger.h"
+#include "gtest/gtest.h"
 
 namespace
 {


### PR DESCRIPTION
These changes introduce a build option to enable or disable syslog for systems that do not have that logging facility.  It is on by default, except for WIN32 platforms.